### PR TITLE
add fix for resetting pieces upon pressing thumbnail

### DIFF
--- a/script/imageAnim.js
+++ b/script/imageAnim.js
@@ -54,7 +54,13 @@
 	function resetPuzzlePieces() {
 		// empty the container!!! dont fill it up too much :(
 		piecesBoard.innerHTML = "";
-		createPuzzlePieces(this.dataset.puzzleref);		
+		createPuzzlePieces(this.dataset.puzzleref);
+
+		 var photoReset = document.getElementsByClassName("puzzle-image");
+    			while(photoReset.length > 4){
+        		photoReset[4].parentNode.removeChild(photoReset[4]);
+    	}
+
 	}
 
 	puzzleSelectors.forEach(puzzle => puzzle.addEventListener("click", resetPuzzlePieces));


### PR DESCRIPTION
I added the script to reset the puzzle pieces when changing to a new puzzle. Originally you would click on a new thumbnail and none of the pieces would appear. The fix makes sure that the pieces all reset and show when the new board is shown.